### PR TITLE
Draft: Fixes the erroneous toolabar

### DIFF
--- a/wled-native/View/DeviceListView.swift
+++ b/wled-native/View/DeviceListView.swift
@@ -92,7 +92,9 @@ struct DeviceListView: View {
     @ViewBuilder
     private var detailView: some View {
         if let device = selection {
-            DeviceView()
+            NavigationStack {
+                DeviceView()
+            }
                 .environmentObject(device)
         } else {
             Text("Select A Device")

--- a/wled-native/View/DeviceView.swift
+++ b/wled-native/View/DeviceView.swift
@@ -8,6 +8,8 @@ struct DeviceView: View {
     @State var showDownloadFinished = false
     @State var shouldWebViewRefresh = false
     
+    @State var showEditDeviceView = false
+    
     var body: some View {
         ZStack {
             WebView(url: getDeviceAddress(), reload: $shouldWebViewRefresh) { filePathDestination in
@@ -33,21 +35,28 @@ struct DeviceView: View {
         }
         .navigationTitle(getDeviceName())
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            ToolbarItemGroup(placement: .primaryAction) {
-                Button {
-                    shouldWebViewRefresh = true
-                } label: {
-                    Image(systemName: "arrow.clockwise")
-                }
-                
-                NavigationLink {
-                    DeviceEditView()
-                        .environmentObject(device)
-                } label: {
-                    Image(systemName: "gear")
-                }
-                .overlay(ToolbarBadge(value: .constant(getToolbarBadgeCount())))
+        .toolbar { toolbar }
+    }
+    
+    
+    @ToolbarContentBuilder
+    var toolbar: some ToolbarContent {
+        ToolbarItem(placement: .navigation) {
+            NavigationLink {
+                DeviceEditView()
+                    .environmentObject(device)
+            } label: {
+                Image(systemName: "gear")
+            }
+            .overlay(alignment: .bottomTrailing) {
+                ToolbarBadge(value: .constant(getToolbarBadgeCount()))
+            }
+        }
+        ToolbarItem(placement: .automatic) {
+            Button {
+                shouldWebViewRefresh = true
+            } label: {
+                Image(systemName: "arrow.clockwise")
             }
         }
     }


### PR DESCRIPTION
Adds a missing `NavigationStack` and fixes erroneous toolabar

Note: there is still the bug when on iOS 18 after a switch to the home screen all `ToolbarItem`s disappear.