### PR TITLE
Add column visibility state to NavigationSplitView

### DIFF
--- a/wled/View/DeviceListView.swift
+++ b/wled/View/DeviceListView.swift
@@ -14,6 +14,7 @@ struct DeviceListView: View {
     @State private var addDeviceButtonActive: Bool = false
     @State private var showSettingsSheet: Bool = false
     @State private var currentTime = Date()
+    @State private var columnVisibility = NavigationSplitViewVisibility.doubleColumn
 
     @AppStorage("DeviceListView.showHiddenDevices") private var showHiddenDevices: Bool = false
     @AppStorage("DeviceListView.showOfflineDevices") private var showOfflineDevices: Bool = true
@@ -74,7 +75,7 @@ struct DeviceListView: View {
     //MARK: - Body
 
     var body: some View {
-        NavigationSplitView {
+        NavigationSplitView(columnVisibility: $columnVisibility) {
             list
                 .toolbar{ toolbar }
                 .sheet(isPresented: $addDeviceButtonActive) {
@@ -90,6 +91,7 @@ struct DeviceListView: View {
         } detail: {
             detailView
         }
+        .navigationSplitViewStyle(.balanced)
         .onAppear(perform: appearAction)
         .onReceive(timer) { input in
             withAnimation {


### PR DESCRIPTION
Introduces a @State property to manage NavigationSplitView's column visibility and applies the .balanced style. This allows for better control over the split view's appearance and behavior.

The goal is to make sure the side bar (list of devices) is always visible at launch on ipad, even on portrait orientation (especially before iOS 26).