### PR TITLE
Add respect repo support

### DIFF
--- a/Data/wled_native_data.xcdatamodeld/.xccurrentversion
+++ b/Data/wled_native_data.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>v2.xcdatamodel</string>
+	<string>v3.xcdatamodel</string>
 </dict>
 </plist>

--- a/Data/wled_native_data.xcdatamodeld/v3.xcdatamodel/contents
+++ b/Data/wled_native_data.xcdatamodeld/v3.xcdatamodel/contents
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24411" systemVersion="25B78" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="Asset" representedClassName="Asset" syncable="YES" codeGenerationType="class">
+        <attribute name="assetId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="downloadUrl" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="size" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="versionTagName" attributeType="String"/>
+        <relationship name="version" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Version" inverseName="assets" inverseEntity="Version">
+            <userInfo>
+                <entry key="key" value="value"/>
+            </userInfo>
+        </relationship>
+    </entity>
+    <entity name="Device" representedClassName="Device" syncable="YES" codeGenerationType="class">
+        <attribute name="address" attributeType="String"/>
+        <attribute name="branch" optional="YES" attributeType="String"/>
+        <attribute name="customName" optional="YES" attributeType="String"/>
+        <attribute name="isHidden" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="lastSeen" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="macAddress" attributeType="String"/>
+        <attribute name="originalName" optional="YES" attributeType="String"/>
+        <attribute name="repository" optional="YES" attributeType="String"/>
+        <attribute name="skipUpdateTag" optional="YES" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="macAddress"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="Version" representedClassName="Version" syncable="YES" codeGenerationType="class">
+        <attribute name="htmlUrl" optional="YES" attributeType="String"/>
+        <attribute name="isPrerelease" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="publishedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="repository" optional="YES" attributeType="String"/>
+        <attribute name="tagName" attributeType="String"/>
+        <attribute name="versionDescription" optional="YES" attributeType="String"/>
+        <relationship name="assets" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Asset" inverseName="version" inverseEntity="Asset"/>
+    </entity>
+</model>

--- a/wled/Model/DeviceApi/Response/Info.swift
+++ b/wled/Model/DeviceApi/Response/Info.swift
@@ -43,6 +43,8 @@ struct Info: Decodable {
     var product : String?
     var mac : String?
     var ipAddress : String?
+    /// The GitHub repository (owner/name) used for firmware updates. Added in WLED 0.15.2.
+    var repo : String?
     // Missing: u - UserMods
     
     
@@ -80,5 +82,6 @@ struct Info: Decodable {
         case product
         case mac
         case ipAddress = "ip"
+        case repo
     }
 }

--- a/wled/Service/DeviceFirstContactService.swift
+++ b/wled/Service/DeviceFirstContactService.swift
@@ -61,7 +61,8 @@ actor DeviceFirstContactService {
             throw ServiceError.missingMacAddress
         }
 
-        return try await upsertDevice(macAddress: macAddress, hostname: cleanAddress, name: info.name)
+        let repository = getRepositoryFromInfo(info)
+        return try await upsertDevice(macAddress: macAddress, hostname: cleanAddress, name: info.name, repository: repository)
     }
 
     /// Attempts to identify and update a device using only the MAC address from mDNS/Discovery.
@@ -120,6 +121,23 @@ actor DeviceFirstContactService {
         return result
     }
 
+    // MARK: - Repository Resolution
+
+    /// Determines the GitHub repository to use for firmware updates based on device info.
+    ///
+    /// Resolution priority:
+    /// 1. Use the `repo` field from device info if available (added in WLED 0.15.2).
+    /// 2. Fall back to the default WLED repository.
+    ///
+    /// - Parameter info: The device info returned from the WLED API.
+    /// - Returns: A repository string in "owner/name" format.
+    func getRepositoryFromInfo(_ info: Info) -> String {
+        if let repo = info.repo, !repo.isEmpty {
+            return repo
+        }
+        return GithubApi.defaultRepository
+    }
+
     /// Fetches device information from the specified address.
     private func fetchDeviceInfo(address: String) async throws -> Info {
         // Construct URL, ensuring http scheme and json/info path
@@ -142,7 +160,7 @@ actor DeviceFirstContactService {
     }
 
     /// Handles the Core Data logic to find, update, or create the device.
-    private func upsertDevice(macAddress: String, hostname: String, name: String?) async throws -> NSManagedObjectID {
+    private func upsertDevice(macAddress: String, hostname: String, name: String?, repository: String) async throws -> NSManagedObjectID {
         let logger = self.logger
         return try await persistenceController.container.performBackgroundTask { context in
             context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
@@ -155,13 +173,14 @@ actor DeviceFirstContactService {
 
             if let existingDevice = try? context.fetch(request).first {
                 // Check if updates are actually needed to minimize Core Data thrashing
-                if existingDevice.address == hostname && existingDevice.originalName == name {
+                if existingDevice.address == hostname && existingDevice.originalName == name && existingDevice.repository == repository {
                     logger.debug("Device exists and is up to date: \(macAddress)")
                     device = existingDevice
                 } else {
                     logger.debug("Updating existing device: \(macAddress)")
                     existingDevice.address = hostname
                     existingDevice.originalName = name
+                    existingDevice.repository = repository
                     device = existingDevice
                 }
             } else {
@@ -171,6 +190,7 @@ actor DeviceFirstContactService {
                 device.address = hostname
                 device.originalName = name
                 device.isHidden = false
+                device.repository = repository
             }
 
             if context.hasChanges {

--- a/wled/Service/DeviceUpdateService.swift
+++ b/wled/Service/DeviceUpdateService.swift
@@ -74,12 +74,16 @@ class DeviceUpdateService : ObservableObject {
 
     /// Returns the existing GitHub API instance or creates a new one if it doesn't exist.
     ///
+    /// Uses the repository stored in the firmware version record to ensure the binary
+    /// is downloaded from the correct GitHub repository.
+    ///
     /// - Returns: An instance of `GithubApi`.
     func getGithubApi() -> GithubApi {
         if let githubApi = self.githubApi {
             return githubApi
         }
-        let newApi = GithubApi()
+        let repository = version.repository ?? GithubApi.defaultRepository
+        let newApi = GithubApi(repository: repository)
         self.githubApi = newApi
         return newApi
     }

--- a/wled/Service/GithubApi.swift
+++ b/wled/Service/GithubApi.swift
@@ -2,6 +2,8 @@ import Foundation
 import CoreData
 
 final class GithubApi: Sendable {
+    static let defaultRepository = "wled/WLED"
+
     static let urlSession: URLSession = {
         let sessionConfig = URLSessionConfiguration.default
         sessionConfig.timeoutIntervalForRequest = 30
@@ -14,9 +16,26 @@ final class GithubApi: Sendable {
     }
 
     let githubBaseUrl = "https://api.github.com"
-    let repoOwner: String = "WLED"
-    let repoName: String = "WLED"
-    
+    let repoOwner: String
+    let repoName: String
+
+    /// Initializes the GitHub API client for a specific repository.
+    ///
+    /// - Parameter repository: The repository in "owner/name" format (e.g. "wled/WLED").
+    ///   Defaults to the standard WLED repository.
+    init(repository: String = defaultRepository) {
+        let parts = repository.split(separator: "/", maxSplits: 1)
+        if parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty {
+            self.repoOwner = String(parts[0])
+            self.repoName = String(parts[1])
+        } else {
+            print("GithubApi: Invalid repository format '\(repository)', using default")
+            let defaultParts = GithubApi.defaultRepository.split(separator: "/", maxSplits: 1)
+            self.repoOwner = String(defaultParts[0])
+            self.repoName = String(defaultParts[1])
+        }
+    }
+
     private func getApiUrl(path: String) -> URL? {
         let urlString = "\(githubBaseUrl)/\(path)"
         print(urlString)

--- a/wled/Service/ReleaseService.swift
+++ b/wled/Service/ReleaseService.swift
@@ -16,14 +16,16 @@ class ReleaseService {
      * @param branch Which branch to check for the update
      * @param ignoreVersion You can specify a version tag to be ignored as a new version. If this is
      *      set and match with the newest version, no version will be returned
+     * @param repository The GitHub repository (owner/name) to check for updates.
+     *      Defaults to the standard WLED repository.
      * @return The newest version if it is newer than versionName and different than ignoreVersion,
      *      otherwise an empty string.
      */
-    func getNewerReleaseTag(versionName: String, branch: Branch, ignoreVersion: String) -> String {
+    func getNewerReleaseTag(versionName: String, branch: Branch, ignoreVersion: String, repository: String = GithubApi.defaultRepository) -> String {
         if (versionName.isEmpty) {
             return ""
         }
-        let latestVersion = getLatestVersion(branch: branch)
+        let latestVersion = getLatestVersion(branch: branch, repository: repository)
         guard let latestTagName = latestVersion?.tagName, latestTagName != ignoreVersion else {
             return ""
         }
@@ -39,7 +41,7 @@ class ReleaseService {
     }
 
 
-    func getLatestVersion(branch: Branch) -> Version? {
+    func getLatestVersion(branch: Branch, repository: String = GithubApi.defaultRepository) -> Version? {
         let fetchRequest = Version.fetchRequest()
         fetchRequest.fetchLimit = 1
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: "publishedDate", ascending: false)]
@@ -51,6 +53,14 @@ class ReleaseService {
         if (branch == Branch.stable) {
             predicates.append(NSPredicate(format: "isPrerelease == %@", NSNumber(value: false)))
         }
+
+        // Filter by repository, falling back to versions without a repository set
+        // (e.g. versions that were cached before multi-repository support was added).
+        // TODO: Once all users have migrated, this nil fallback can be removed.
+        predicates.append(NSPredicate(
+            format: "repository == %@ OR repository == nil",
+            repository
+        ))
 
         fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
 
@@ -64,31 +74,42 @@ class ReleaseService {
     }
 
 
-    func refreshVersions() async {
-        let allReleases = await GithubApi().getAllReleases()
+    /// Fetches the latest releases for a given repository and refreshes them in Core Data.
+    ///
+    /// - Parameter repository: The GitHub repository (owner/name) to fetch releases for.
+    ///   Defaults to the standard WLED repository.
+    func refreshVersions(repository: String = GithubApi.defaultRepository) async {
+        let allReleases = await GithubApi(repository: repository).getAllReleases()
 
         guard !allReleases.isEmpty else {
-            print("Did not find any releases")
+            print("Did not find any releases for \(repository)")
             return
         }
 
-        // Capture context locally to avoid capturing 'self' in the closure below
+        // Capture context and repository locally to avoid capturing 'self' in the closure below
         let context = self.context
+        let repoToRefresh = repository
         await context.perform {
             do {
-                // Delete existing versions first
+                // Delete existing versions for this repository only.
+                // The nil check handles any legacy versions cached before multi-repository
+                // support was added — they are assumed to belong to the default repository.
                 let fetchRequest = Version.fetchRequest()
+                fetchRequest.predicate = NSPredicate(
+                    format: "repository == %@ OR repository == nil",
+                    repoToRefresh
+                )
                 let versions = try context.fetch(fetchRequest)
-                print("Deleting \(versions.count) versions")
+                print("Deleting \(versions.count) versions for \(repoToRefresh)")
                 for version in versions {
                     context.delete(version)
                 }
 
                 // Create new versions
                 for release in allReleases {
-                    let version = ReleaseService.createVersion(release: release, context: context)
+                    let version = ReleaseService.createVersion(release: release, repository: repoToRefresh, context: context)
                     let assets = ReleaseService.createAssetsForVersion(version: version, release: release, context: context)
-                    print("Added version \(version.tagName ?? "[unknown]") with \(assets.count) assets")
+                    print("Added version \(version.tagName ?? "[unknown]") with \(assets.count) assets for \(repoToRefresh)")
                 }
 
                 try context.save()
@@ -103,7 +124,7 @@ class ReleaseService {
     // MARK: - Static Helpers
     // Made static to avoid capturing 'self' inside async/sendable closures
     
-    private static func createVersion(release: Release, context: NSManagedObjectContext) -> Version {
+    private static func createVersion(release: Release, repository: String, context: NSManagedObjectContext) -> Version {
         let version = Version(context: context)
         // Strip 'v' prefix if present to normalize data with the WLED API
         if release.tagName.hasPrefix("v") {
@@ -115,6 +136,7 @@ class ReleaseService {
         version.versionDescription = release.body
         version.isPrerelease = release.prerelease
         version.htmlUrl = release.htmlUrl
+        version.repository = repository
         
         let dateFormatter = ISO8601DateFormatter()
         version.publishedDate = dateFormatter.date(from: release.publishedAt)

--- a/wled/Service/Websocket/DeviceWithState.swift
+++ b/wled/Service/Websocket/DeviceWithState.swift
@@ -70,17 +70,18 @@ class DeviceWithState: ObservableObject, Identifiable {
             .map { device in
                 // This defines which values in the device can cause a
                 // recalculation of the currently available version.
-                return Publishers.CombineLatest(
+                return Publishers.CombineLatest3(
                     device.publisher(for: \.branch),
-                    device.publisher(for: \.skipUpdateTag)
+                    device.publisher(for: \.skipUpdateTag),
+                    device.publisher(for: \.repository)
                 )
-                .map { (branch: $0, skipTag: $1, device: device) }
+                .map { (branch: $0.0, skipTag: $0.1, repository: $0.2, device: device) }
             }
             .switchToLatest()
             .combineLatest($stateInfo)
             .receive(on: DispatchQueue.main) // Perform logic on Main Thread (safe for Core Data)
             .map { (deviceInputs, stateInfo) -> String? in
-                let (branchRaw, skipTag, device) = deviceInputs
+                let (branchRaw, skipTag, repositoryRaw, device) = deviceInputs
 
                 // Extract necessary info, fail fast if missing
                 guard let info = stateInfo?.info,
@@ -92,12 +93,14 @@ class DeviceWithState: ObservableObject, Identifiable {
                 // Use your existing Service logic
                 // Note: We use the raw strings from Core Data to create the Enum
                 let branchEnum = Branch(rawValue: branchRaw ?? "") ?? .unknown
+                let repository = repositoryRaw ?? GithubApi.defaultRepository
 
                 let releaseService = ReleaseService(context: context)
                 let newerTag = releaseService.getNewerReleaseTag(
                     versionName: currentVersion,
                     branch: branchEnum,
-                    ignoreVersion: skipTag ?? ""
+                    ignoreVersion: skipTag ?? "",
+                    repository: repository
                 )
 
                 return newerTag.isEmpty ? nil : newerTag

--- a/wled/ViewModel/DeviceWebsocketListViewModel.swift
+++ b/wled/ViewModel/DeviceWebsocketListViewModel.swift
@@ -153,6 +153,7 @@ class DeviceWebsocketListViewModel: NSObject, ObservableObject, NSFetchedResults
             // Logic moved from WebsocketClient to here
             let newName = info.info.name
             let newVersion = info.info.version ?? ""
+            let newRepository = self.getRepositoryFromInfo(info.info)
 
             // Flag to determine if we need an immediate disk write
             var structuralChange = false
@@ -169,6 +170,10 @@ class DeviceWebsocketListViewModel: NSObject, ObservableObject, NSFetchedResults
             }
             if device.originalName != newName {
                 device.originalName = newName
+                structuralChange = true
+            }
+            if device.repository != newRepository {
+                device.repository = newRepository
                 structuralChange = true
             }
 
@@ -257,6 +262,15 @@ class DeviceWebsocketListViewModel: NSObject, ObservableObject, NSFetchedResults
                 try? ctx.save()
             }
         }
+    }
+
+    // MARK: - Repository Resolution
+
+    private func getRepositoryFromInfo(_ info: Info) -> String {
+        if let repo = info.repo, !repo.isEmpty {
+            return repo
+        }
+        return GithubApi.defaultRepository
     }
 
     // MARK: - Discovery Logic

--- a/wled/WLEDNativeApp.swift
+++ b/wled/WLEDNativeApp.swift
@@ -34,7 +34,29 @@ struct WLEDNativeApp: App {
                 return
             }
             print("Refreshing available Releases")
-            await ReleaseService(context: persistenceController.container.viewContext).refreshVersions()
+
+            // Collect all unique repositories used by known devices so we fetch
+            // releases from the correct GitHub repo for each device.
+            // Always include the default WLED repository to support pre-0.15.2 devices
+            // that don't report a repo field.
+            let context = persistenceController.container.viewContext
+            let repositories: Set<String> = await context.perform {
+                let request: NSFetchRequest<Device> = Device.fetchRequest()
+                let devices = (try? context.fetch(request)) ?? []
+                var repos = Set<String>([GithubApi.defaultRepository])
+                for device in devices {
+                    if let repository = device.repository, !repository.isEmpty {
+                        repos.insert(repository)
+                    }
+                }
+                return repos
+            }
+
+            let releaseService = ReleaseService(context: context)
+            for repository in repositories {
+                await releaseService.refreshVersions(repository: repository)
+            }
+
             UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: WLEDNativeApp.dateLastUpdateKey)
         }
     }


### PR DESCRIPTION
WLED 0.15.2 added a `repo` field to the device info API (`/json/info`) that specifies the GitHub repository (`owner/name`) a device should use for firmware updates — enabling forks to point to their own releases instead of always using `wled/WLED`.

## Changes

### API / Model
- **`Info.swift`**: Added `repo: String?` decoded from JSON key `"repo"`

### Core Data (v2 → v3 migration)
- **`v3.xcdatamodel`**: Added optional `repository: String` attribute to `Device` and `Version` entities; lightweight automatic migration handles existing data

### GitHub API
- **`GithubApi`**: Added `static let defaultRepository = "wled/WLED"`; `repoOwner`/`repoName` now set via `init(repository:)` parsing `owner/name` format with fallback to default on invalid input

### Release management
- **`ReleaseService`**: `refreshVersions`, `getLatestVersion`, and `getNewerReleaseTag` all accept a `repository` parameter (default: `GithubApi.defaultRepository`); versions are filtered and stored by repository; nil-repository versions fall back gracefully for backward compatibility
- **`WLEDNativeApp`**: On startup refresh, collects distinct `device.repository` values and fetches releases from each; always includes the default repo for pre-0.15.2 devices

### Device lifecycle
- **`DeviceFirstContactService`**: `getRepositoryFromInfo(_:)` resolves repo from `info.repo` or defaults; persisted on device create/update
- **`DeviceWebsocketListViewModel`**: Updates `device.repository` whenever a WebSocket state push is received
- **`DeviceWithState`**: Update-availability pipeline extended with `CombineLatest3` to re-evaluate when `device.repository` changes; repository passed through to `getNewerReleaseTag`
- **`DeviceUpdateService`**: `GithubApi` initialised with `version.repository` so firmware binaries are fetched from the correct repo

```swift
// Example: device running a fork reports its own repo
// GET /json/info → { "repo": "QuinLED/WLED", ... }
// App now fetches releases from github.com/QuinLED/WLED
let api = GithubApi(repository: device.repository ?? GithubApi.defaultRepository)
```

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.