### PR TITLE
Improved Device List Performance & UI Responsiveness

### DIFF
--- a/wled/Service/Websocket/DeviceWithState.swift
+++ b/wled/Service/Websocket/DeviceWithState.swift
@@ -42,7 +42,11 @@ class DeviceWithState: ObservableObject, Identifiable {
 
     private func setDeviceWillChange() {
         // Forward changes from the inner Core Data Device to this wrapper
+        // Throttled to prevent high-frequency metadata changes (e.g. lastSeen)
+        // from spamming objectWillChange. Critical state like stateInfo and
+        // websocketStatus are @Published directly and bypass this throttle.
         device.objectWillChange
+            .throttle(for: .milliseconds(500), scheduler: DispatchQueue.main, latest: true)
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
             }
@@ -77,7 +81,14 @@ class DeviceWithState: ObservableObject, Identifiable {
                 .map { (branch: $0, skipTag: $1, device: device) }
             }
             .switchToLatest()
-            .combineLatest($stateInfo)
+            .combineLatest(
+                $stateInfo
+                    .debounce(for: .seconds(2), scheduler: DispatchQueue.main)
+            )
+            .removeDuplicates { prev, curr in
+                // Only re-query Core Data if the firmware version actually changed
+                prev.1?.info.version == curr.1?.info.version
+            }
             .receive(on: DispatchQueue.main) // Perform logic on Main Thread (safe for Core Data)
             .map { (deviceInputs, stateInfo) -> String? in
                 let (branchRaw, skipTag, device) = deviceInputs

--- a/wled/Service/Websocket/WebsocketClient.swift
+++ b/wled/Service/Websocket/WebsocketClient.swift
@@ -149,12 +149,13 @@ class WebsocketClient: NSObject, ObservableObject, URLSessionWebSocketDelegate {
     }
     
     private func handleMessage(_ text: String) {
+        let decoder = self.decoder
         Task.detached(priority: .userInitiated) { [weak self] in
             guard let self = self else { return }
             guard let data = text.data(using: .utf8) else { return }
 
             do {
-                let info = try JSONDecoder().decode(DeviceStateInfo.self, from: data)
+                let info = try decoder.decode(DeviceStateInfo.self, from: data)
                 await MainActor.run {
                     self.deviceState.stateInfo = info
 

--- a/wled/ViewModel/DeviceWebsocketListViewModel.swift
+++ b/wled/ViewModel/DeviceWebsocketListViewModel.swift
@@ -96,6 +96,7 @@ class DeviceWebsocketListViewModel: NSObject, ObservableObject, NSFetchedResults
                     .prepend(()) // Trigger immediately when the list changes
             }
             .switchToLatest()
+            .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.updateFilteredDevices(currentTime: Date())
             }

--- a/wledTests/DeviceWebsocketListViewModelTests.swift
+++ b/wledTests/DeviceWebsocketListViewModelTests.swift
@@ -66,9 +66,9 @@ struct DeviceWebsocketListViewModelTests {
         #expect(viewModel.offlineDevices.count == 1)
         #expect(viewModel.onlineDevices.isEmpty)
 
-        // Switch to connected — the reactive pipeline triggers immediately (no debounce)
+        // Switch to connected — the reactive pipeline triggers after debounce
         mockClient.setStatus(.connected)
-        try await Task.sleep(for: .milliseconds(100)) // Brief yield for Combine pipeline
+        try await Task.sleep(for: .milliseconds(500)) // Wait for 200ms debounce + Combine propagation
         
         #expect(viewModel.onlineDevices.count == 1)
         #expect(viewModel.offlineDevices.isEmpty)


### PR DESCRIPTION

## Summary
This PR addresses reported UI sluggishness and performance issues in the device list. The root cause was a "notification storm" where every incoming websocket message from any device triggered a full re-sort and re-filter of the entire device list, creating O(N²) UI re-evaluations per second.

## Key Changes

### 1. Coalesced UI Updates (ViewModel throttle)
*   **Added a 200ms debounce** to the reactive pipeline in `DeviceWebsocketListViewModel`.
*   Previously, the ViewModel's `MergeMany` pipeline observed every single `objectWillChange` signal from every device. In an environment with multiple WLED devices sending frequent status updates, this caused constant, redundant filtering and sorting of the list.
*   The 200ms debounce coalesces these rapid updates into a single UI refresh per frame cycle, significantly reducing the CPU load without perceptible lag.

### 2. Throttled Database Notifications
*   **Added a 500ms throttle** to the Core Data `objectWillChange` forwarding in `DeviceWithState`.
*   This prevents high-frequency metadata changes (like `lastSeen` timestamps) from triggering wrapper-level notifications too often. 
*   **Note:** Critical user-facing state (like power status and brightness) is `@Published` directly and bypasses this throttle, ensuring the UI remains snappy for manual interactions.

### 3. Eliminated Redundant Core Data Fetches
*   Refactored the firmware update check in `DeviceWithState` to use a **2-second debounce and `removeDuplicates`**.
*   The app was executing a Core Data fetch (via `ReleaseService`) on **every single websocket message** to check for newer firmware.
*   The new logic now only queries the database when the device's reported firmware version actually changes or after the initial connection has settled.

### 4. Optimized Memory & CPU (JSON Decoding)
*   Modified `WebsocketClient` to **reuse a single `JSONDecoder` instance** instead of allocating a new one for every incoming message. This reduces memory churn and allocation overhead for high-frequency data streams.

## Verification

### Automated Tests
*   Updated `DeviceWebsocketListViewModelTests` to account for the new debounce windows.
*   Verified that all reactive transitions (Online/Offline status changes) still work correctly.
*   `** TEST SUCCEEDED **`

### Manual Verification
*   Observed significantly smoother scrolling and interaction in the device list when multiple devices are active.
*   Verified that manual toggles (Power/Brightness) still respond immediately.

(This was written with the help of AI tools)