### PR TITLE
Fix Premature WebSocket Disconnection During App Switcher Gestures

### DIFF
--- a/wled/View/DeviceListView.swift
+++ b/wled/View/DeviceListView.swift
@@ -60,8 +60,10 @@ struct DeviceListView: View {
             switch newPhase {
             case .active:
                 viewModel.onResume()
-            case .background, .inactive:
+            case .background:
                 viewModel.onPause()
+            case .inactive:
+                break // Don't disconnect during transient gestures (app switcher, notifications)
             @unknown default:
                 break
             }

--- a/wled/ViewModel/DeviceWebsocketListViewModel.swift
+++ b/wled/ViewModel/DeviceWebsocketListViewModel.swift
@@ -46,6 +46,7 @@ class DeviceWebsocketListViewModel: NSObject, ObservableObject, NSFetchedResults
     
     private var activeClients: [String: ClientWrapper] = [:]
     private var isPaused = false
+    private var backgroundTask: Task<Void, Never>?
     
     /// Amount of time after a device becomes offline before it is considered offline.
     private let offlineGracePeriod: TimeInterval = 60
@@ -251,18 +252,30 @@ class DeviceWebsocketListViewModel: NSObject, ObservableObject, NSFetchedResults
     // MARK: - Lifecycle (Call these from App ScenePhase)
     
     func onPause() {
-        print("[ListVM] onPause: Pausing all connections.")
-        isPaused = true
-        activeClients.values.forEach { $0.client.disconnect() }
-        
-        // SAVE: Persist "lastSeen" and other pending changes when app goes to background
-        if context.hasChanges {
-            try? context.save()
+        print("[ListVM] onPause: Scheduling disconnect.")
+        backgroundTask?.cancel()
+        backgroundTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(for: .seconds(2))
+            } catch {
+                // Task was cancelled (user came back quickly)
+                return
+            }
+            guard let self = self else { return }
+            print("[ListVM] onPause: Disconnecting all connections.")
+            self.isPaused = true
+            self.activeClients.values.forEach { $0.client.disconnect() }
+            if self.context.hasChanges {
+                try? self.context.save()
+            }
         }
     }
     
     func onResume() {
-        print("[ListVM] onResume: Resuming all connections.")
+        print("[ListVM] onResume: Cancelling pending disconnect and resuming.")
+        backgroundTask?.cancel()
+        backgroundTask = nil
+        guard isPaused else { return } // Nothing to resume if we never disconnected
         isPaused = false
         activeClients.values.forEach { $0.client.connect() }
     }

--- a/wledTests/DeviceWebsocketListViewModelTests.swift
+++ b/wledTests/DeviceWebsocketListViewModelTests.swift
@@ -84,6 +84,51 @@ struct DeviceWebsocketListViewModelTests {
         device.isHidden = isHidden
         return device
     }
+
+    @Test func testQuickResumeDoesNotDisconnect() async throws {
+        let device = createDevice(name: "Test Device", mac: "01", isHidden: false)
+        try context.save()
+
+        let viewModel = DeviceWebsocketListViewModel(context: context)
+        let mockClient = ManualMockWebsocketClient(device: device)
+        viewModel.makeClient = { _ in mockClient }
+
+        viewModel.load()
+        mockClient.setStatus(.connected)
+        viewModel.updateFilteredDevices(currentTime: Date())
+        #expect(viewModel.onlineDevices.count == 1)
+
+        // Simulate quick background + resume (app switcher peek)
+        viewModel.onPause()
+        try await Task.sleep(for: .milliseconds(200)) // Well under the 2s delay
+        viewModel.onResume()
+
+        // Device should still be connected — disconnect was cancelled
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(mockClient.deviceState.websocketStatus == .connected)
+        #expect(viewModel.onlineDevices.count == 1)
+    }
+
+    @Test func testFullBackgroundDisconnectsAfterDelay() async throws {
+        let device = createDevice(name: "Test Device", mac: "01", isHidden: false)
+        try context.save()
+
+        let viewModel = DeviceWebsocketListViewModel(context: context)
+        let mockClient = ManualMockWebsocketClient(device: device)
+        viewModel.makeClient = { _ in mockClient }
+
+        viewModel.load()
+        mockClient.setStatus(.connected)
+        viewModel.updateFilteredDevices(currentTime: Date())
+        #expect(viewModel.onlineDevices.count == 1)
+
+        // Simulate going to background and staying there
+        viewModel.onPause()
+        try await Task.sleep(for: .seconds(2.5)) // Wait past the 2s delay
+
+        // Device should now be disconnected
+        #expect(mockClient.deviceState.websocketStatus == .disconnected)
+    }
 }
 
 // Precise control mock
@@ -93,5 +138,8 @@ class ManualMockWebsocketClient: WebsocketClient {
     }
     
     override func connect() { /* no-op */ }
-    override func disconnect() { /* no-op */ }
+    override func disconnect() {
+        self.deviceState.websocketStatus = .disconnected
+    }
 }
+


### PR DESCRIPTION
## Description
This PR addresses an issue where all WLED devices would immediately show as "offline" as soon as the user began a gesture to open the iOS app switcher (or opened the Notification Center / Control Center). 

### The Problem
The `DeviceListView` was previously triggering a full WebSocket disconnect on both `.inactive` and `.background` scene phases. However, iOS transitions an app to the `.inactive` state the moment a system gesture begins. This resulted in an immediate loss of live status in the app switcher preview and unnecessary connection churn during transient interactions.

### The Solution
1. **Scene Phase Refinement**: Updated `DeviceListView` to only trigger the pause logic when the scene truly enters the `.background` state. The `.inactive` state is now ignored, allowing connections to persist during gestures, alerts, and system overlays.
2. **Delayed Disconnect**: Implemented a 2-second grace period in `DeviceWebsocketListViewModel`. When the app enters the background, a deferred task is scheduled to disconnect the WebSockets.
3. **Cancellation Logic**: If the user returns to the app within those 2 seconds (e.g., a quick "peek" at another app), the disconnect task is cancelled, and the existing connections are maintained without interruption.

## Changes
- **DeviceListView.swift**: Modified `onChange(of: scenePhase)` to ignore `.inactive`.
- **DeviceWebsocketListViewModel.swift**: Added `backgroundTask` management to `onPause()` and `onResume()` to handle the 2-second delayed disconnection.
- **DeviceWebsocketListViewModelTests.swift**: Added two new test cases:
    - `testQuickResumeDoesNotDisconnect`: Verifies connections stay alive if back within the grace period.
    - `testFullBackgroundDisconnectsAfterDelay`: Verifies connections do eventually close after 2 seconds in the background.

## Verification Results
- ✅ All automated tests passed, including new lifecycle cases.
- ✅ Manual verification on simulator confirms devices remain "Online" during the app switcher swipe gesture and only transition to offline after ~2 seconds of being fully backgrounded.

(This PR was written with the help of AI tools)