### PR TITLE
Fix power toggle gesture conflict on iOS 16

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,15 +19,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Install xcbeautify
+        run: brew install xcbeautify
+
       - name: Build and Test
         run: |
+          set -o pipefail
           xcodebuild test \
             -project wled.xcodeproj \
             -scheme wled \
             -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' \
             -skipPackagePluginValidation \
             -skipMacroValidation \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+            -resultBundlePath TestResults.xcresult \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO \
+            2>&1 | xcbeautify --report junit --report-path . --junit-report-filename junit.xml
 
   lint:
     name: Run Lint

--- a/wled/View/DeviceListItemView.swift
+++ b/wled/View/DeviceListItemView.swift
@@ -26,6 +26,11 @@ struct DeviceListItemView: View {
                 Toggle("Turn On/Off", isOn: isOnBinding)
                     .labelsHidden()
                     .frame(alignment: .trailing)
+                    // On iOS 16, tapping the Toggle also triggers the parent row's .onTapGesture.
+                    // This empty handler "consumes" the SwiftUI tap at the child level,
+                    // while the underlying UISwitch still receives the UIKit event.
+                    // This can be removed once the minimum deployment target is iOS 17+.
+                    .onTapGesture { }
             }
 
             Slider(

--- a/wled/ViewModel/DeviceWebsocketListViewModel.swift
+++ b/wled/ViewModel/DeviceWebsocketListViewModel.swift
@@ -49,6 +49,10 @@ class DeviceWebsocketListViewModel: NSObject, ObservableObject, NSFetchedResults
     private var activeClients: [String: ClientWrapper] = [:]
     private var isPaused = false
     private var backgroundTask: Task<Void, Never>?
+
+    /// Delay before disconnecting websockets after entering background.
+    /// Exposed as `internal` so tests can override with a shorter value.
+    var backgroundDisconnectDelay: Duration = .seconds(2)
     
     /// Amount of time after a device becomes offline before it is considered offline.
     private let offlineGracePeriod: TimeInterval = 60
@@ -265,9 +269,10 @@ class DeviceWebsocketListViewModel: NSObject, ObservableObject, NSFetchedResults
     func onPause() {
         print("[ListVM] onPause: Scheduling disconnect.")
         backgroundTask?.cancel()
+        let delay = backgroundDisconnectDelay
         backgroundTask = Task { @MainActor [weak self] in
             do {
-                try await Task.sleep(for: .seconds(2))
+                try await Task.sleep(for: delay)
             } catch {
                 // Task was cancelled (user came back quickly)
                 return

--- a/wledTests/DeviceWebsocketListViewModelTests.swift
+++ b/wledTests/DeviceWebsocketListViewModelTests.swift
@@ -81,6 +81,7 @@ struct DeviceWebsocketListViewModelTests {
         try context.save()
 
         let viewModel = DeviceWebsocketListViewModel(context: context)
+        viewModel.backgroundDisconnectDelay = .milliseconds(500)
         let mockClient = ManualMockWebsocketClient(device: device)
         viewModel.makeClient = { _ in mockClient }
 
@@ -91,11 +92,11 @@ struct DeviceWebsocketListViewModelTests {
 
         // Simulate quick background + resume (app switcher peek)
         viewModel.onPause()
-        try await Task.sleep(for: .milliseconds(500)) // Well under the 2s delay
+        try await Task.sleep(for: .milliseconds(100)) // Well under the 500ms delay
         viewModel.onResume()
 
         // Device should still be connected — disconnect was cancelled
-        try await Task.sleep(for: .seconds(1))
+        try await Task.sleep(for: .milliseconds(600))
         #expect(mockClient.deviceState.websocketStatus == .connected)
         #expect(viewModel.onlineDevices.count == 1)
     }
@@ -105,6 +106,7 @@ struct DeviceWebsocketListViewModelTests {
         try context.save()
 
         let viewModel = DeviceWebsocketListViewModel(context: context)
+        viewModel.backgroundDisconnectDelay = .milliseconds(100)
         let mockClient = ManualMockWebsocketClient(device: device)
         viewModel.makeClient = { _ in mockClient }
 
@@ -115,7 +117,7 @@ struct DeviceWebsocketListViewModelTests {
 
         // Simulate going to background and staying there
         viewModel.onPause()
-        try await Task.sleep(for: .seconds(4)) // Wait well past the 2s delay (generous for CI)
+        try await Task.sleep(for: .milliseconds(500)) // Wait well past the 100ms delay
 
         // Device should now be disconnected
         #expect(mockClient.deviceState.websocketStatus == .disconnected)

--- a/wledTests/DeviceWebsocketListViewModelTests.swift
+++ b/wledTests/DeviceWebsocketListViewModelTests.swift
@@ -81,6 +81,9 @@ struct DeviceWebsocketListViewModelTests {
         try context.save()
 
         let viewModel = DeviceWebsocketListViewModel(context: context)
+        // Use a very long delay so the disconnect can never fire during this test,
+        // even on a slow CI runner. We only care that onResume() cancels it.
+        viewModel.backgroundDisconnectDelay = .seconds(60)
         let mockClient = ManualMockWebsocketClient(device: device)
         viewModel.makeClient = { _ in mockClient }
 
@@ -91,11 +94,11 @@ struct DeviceWebsocketListViewModelTests {
 
         // Simulate quick background + resume (app switcher peek)
         viewModel.onPause()
-        try await Task.sleep(for: .milliseconds(500)) // Well under the 2s delay
+        try await Task.sleep(for: .milliseconds(200))
         viewModel.onResume()
 
         // Device should still be connected — disconnect was cancelled
-        try await Task.sleep(for: .seconds(1))
+        try await Task.sleep(for: .milliseconds(500))
         #expect(mockClient.deviceState.websocketStatus == .connected)
         #expect(viewModel.onlineDevices.count == 1)
     }
@@ -105,6 +108,7 @@ struct DeviceWebsocketListViewModelTests {
         try context.save()
 
         let viewModel = DeviceWebsocketListViewModel(context: context)
+        viewModel.backgroundDisconnectDelay = .milliseconds(100)
         let mockClient = ManualMockWebsocketClient(device: device)
         viewModel.makeClient = { _ in mockClient }
 
@@ -115,7 +119,7 @@ struct DeviceWebsocketListViewModelTests {
 
         // Simulate going to background and staying there
         viewModel.onPause()
-        try await Task.sleep(for: .seconds(4)) // Wait well past the 2s delay (generous for CI)
+        try await Task.sleep(for: .milliseconds(500)) // Wait well past the 100ms delay
 
         // Device should now be disconnected
         #expect(mockClient.deviceState.websocketStatus == .disconnected)


### PR DESCRIPTION
## 🛠️ Fix: Power Toggle Gesture Conflict on iOS 16

This fixes #73 

### 📝 Summary
This PR fixes a bug on iOS 16 where tapping a device's power toggle in the list would simultaneously open the device detail view. 

On iOS 16, SwiftUI's `.onTapGesture` on a parent (the List row) is too "greedy" and triggers even when a child interactive control like a `Toggle` is tapped. This resulted in the app toggling the power *and* navigating to the detail screen at the same time.

### 💡 The Solution
Added an **empty** `.onTapGesture { }` specifically to the child `Toggle`. SwiftUI's gesture system prioritizes the child's (more specific) gesture recognizer. This empty handler "claims" the tap, preventing it from bubbling up to the parent row. Because the `Toggle` uses UIKit's `UISwitch` under the hood, it still correctly receives the touch event via UIKit and functions normally.

### ✅ Verified
- [x] Tapping the power toggle on iOS 16 toggles the device **without** navigating.
- [x] Tapping the power toggle on later iOS versions (iOS 17+) does not trigger navigation.
- [x] Tapping elsewhere on the device card still triggers navigation correctly.